### PR TITLE
修复了可能会使DingtalkServer出现uninitialized constant的问题

### DIFF
--- a/lib/dingtalk/server/user.rb
+++ b/lib/dingtalk/server/user.rb
@@ -1,3 +1,4 @@
+require 'net/http'
 require_relative 'server'
 
 module Dingtalk


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12070302/27536228-db24fbfc-5aa0-11e7-9623-535b1acaebf9.png)
此问题是由于没有在调用query_all_users的文件中require 'net'导致的。